### PR TITLE
カレンダープログラム・課題提出

### DIFF
--- a/02.calendar/cal.rb
+++ b/02.calendar/cal.rb
@@ -1,0 +1,33 @@
+#!/usr/bin/env ruby
+
+require "optparse"
+require "date"
+
+options = {}
+
+OptionParser.new do |opts|
+  opts.on("-y YEAR", "年を指定") do |y|
+    options[:year] = y
+  end
+
+  opts.on("-m MONTH", "月を指定") do |m|
+    options[:month] = m
+  end
+end.parse!
+
+options[:year] ||= Date.today.year
+options[:month] ||= Date.today.month
+
+first_day = Date.new(options[:year].to_i, options[:month].to_i, 1)
+last_day = Date.new(first_day.year, first_day.month, -1)
+all_days = (first_day..last_day).to_a
+
+puts "#{options[:month]}月 #{options[:year]}".center(20)
+puts "日 月 火 水 木 金 土 "
+
+first_space = first_day.wday
+first_space.times { all_days.unshift(nil) }
+
+all_days.each_slice(7) do |calender_dates|
+  puts calender_dates.map { |d| d ? d.strftime("%-d").rjust(2) : "  " }.join(" ")
+end


### PR DESCRIPTION
## 該当プラクティス
[プラクティス カレンダーのプログラム\(Ruby\) \| FBC](https://bootcamp.fjord.jp/practices/194)

## 実行結果
![image](https://github.com/user-attachments/assets/85f34886-152c-4ca2-92a6-1feb1b96eaa7)


## 終了条件
提出物
- PRのURL
- Terminalでの実行結果

条件
- ./cal.rb で実行できること(ruby cal.rb としなくてよいこと)

- -mで月を、-yで年を指定できる

- 引数を指定しない場合は、今月・今年のカレンダーが表示される
- MacやWSLに入っているcalコマンドと同じ見た目になっている

- 少なくとも1970年から2100年までは正しく表示される